### PR TITLE
[travix-ui-kit] Properly forward Modal data attributes to Global component

### DIFF
--- a/packages/travix-ui-kit/components/global/global.js
+++ b/packages/travix-ui-kit/components/global/global.js
@@ -4,6 +4,8 @@ import {
   createPortal,
 } from 'react-dom';
 
+import { getDataAttributes } from '../_helpers';
+
 /**
  * Global component
  * React component for transportation of modals, lightboxes, loading bars... to document.body
@@ -57,12 +59,19 @@ class Global extends Component {
   }
 
   render() {
+    const {
+      children,
+      className,
+      dataAttrs,
+    } = this.props;
+
     return createPortal((
       <div
-        className={this.props.className}
+        {...getDataAttributes(dataAttrs)}
+        className={className}
         onClick={this.handleClick}
       >
-        {this.props.children}
+        {children}
       </div>
     ), this.target);
   }
@@ -81,6 +90,13 @@ Global.propTypes = {
    * The modal dialog's body
    */
   children: PropTypes.node,
+  /**
+   * Data attribute. You can use it to set up GTM key or any custom data-* attribute
+   */
+  dataAttrs: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.object,
+  ]),
   /**
    * Determine whether a body is scrollable or not
    */

--- a/packages/travix-ui-kit/components/modal/modal.js
+++ b/packages/travix-ui-kit/components/modal/modal.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 
 import Global from '../global/global';
 import KEY_CODE from '../constants/keyCode';
-import { getClassNamesWithMods, getDataAttributes, warnAboutDeprecatedProp } from '../_helpers';
+import { getClassNamesWithMods, warnAboutDeprecatedProp } from '../_helpers';
 
 /**
  * Modal component
@@ -192,7 +192,7 @@ class Modal extends Component {
     const classes = classnames(className, classNameWithMods);
 
     return (
-      <Global className={classes} {...getDataAttributes(dataAttrs)} noscroll={isOpen}>
+      <Global className={classes} dataAttrs={dataAttrs} noscroll={isOpen}>
         {this.renderOverlay()}
         <div className={'ui-modal__container'}>
           {this.renderHeader()}

--- a/packages/travix-ui-kit/tests/unit/modal/__snapshots__/modal.render.spec.js.snap
+++ b/packages/travix-ui-kit/tests/unit/modal/__snapshots__/modal.render.spec.js.snap
@@ -438,11 +438,16 @@ exports[`Modal: render should render modal with provided dataAttrs 1`] = `
 >
   <Global
     className="ui-modal ui-modal_active"
-    data-gtm="id"
+    dataAttrs={
+      Object {
+        "gtm": "id",
+      }
+    }
     noscroll={false}
   >
     <div
       className="ui-modal ui-modal_active"
+      data-gtm="id"
       onClick={[Function]}
     >
       <div


### PR DESCRIPTION
# What does this PR do

There are two issues at play here:

1. `Modal` spreads its `dataAttrs` prop as props to `Global` component, instead of forwarding the original object. However, `Global` component does not spread rest props to its rendered element.
2. `Global` component does not have a `dataAttrs` prop, so even if `Modal` component forwarded the whole object, the data attributes would never be rendered to the DOM.

This PR fixes both issues by forwarding the original `dataAttrs` prop from `Modal` to `Global` component, and making `Global` component render the data attributes to the DOM.

# Where should the reviewer start

Review the changes, noting the GTM ID data attribute now showing up in the `Modal` test snapshot as expected.