### PR TITLE
Fix sliding panel migration state

### DIFF
--- a/packages/travix-ui-kit/components/slidingPanel/slidingPanel.css
+++ b/packages/travix-ui-kit/components/slidingPanel/slidingPanel.css
@@ -54,6 +54,12 @@
   animation: sidePanelLeftOpen 195ms ease-in-out 0s 1 both;
 }
 
+.ui-sliding-panel-content-wrapper {
+  flex: var(--tx-sliding-panel-content-flex);
+  overflow: var(--tx-sliding-panel-content-overflow);
+  overflow-y: var(--tx-sliding-panel-content-overflow-y);
+}
+
 @keyframes sidePanelOpen {
   0% {
     transform: translateX(100%);

--- a/packages/travix-ui-kit/components/slidingPanel/slidingPanel.js
+++ b/packages/travix-ui-kit/components/slidingPanel/slidingPanel.js
@@ -163,8 +163,8 @@ export default class SlidingPanel extends Component {
     ** parameters and will support SlidingPanelHeader and SlidingPanelFooter. React components
     ** will overides any property definition.
     **
-    ** We also will encapsulate all components using SlidingPanelContent as an temporary solution.
-    ** After the migration process it will be removed and every child will have to define it, if needed.
+    ** We also will encapsulate all components using SlidingPanelContent as a temporary solution.
+    ** After the migration process ends it will be removed and every child will have to define it if needed.
     */
 
     Children.forEach(children, (child) => {

--- a/packages/travix-ui-kit/components/slidingPanel/slidingPanel.js
+++ b/packages/travix-ui-kit/components/slidingPanel/slidingPanel.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
-import React, { Component } from 'react';
+import React, { Children, Component } from 'react';
 import classnames from 'classnames';
 
+import SlidingPanelContent from './slidingPanelContent/slidingPanelContent';
 import SlidingPanelHeader from './slidingPanelHeader/slidingPanelHeader';
 import SlidingPanelFooter from './slidingPanelFooter/slidingPanelFooter';
 import Global from '../global/global';
@@ -132,6 +133,62 @@ export default class SlidingPanel extends Component {
     const panelClassName = classnames(getClassNamesWithMods('ui-sliding-panel', panelMods), className);
     const overlayClassName = getClassNamesWithMods('ui-sliding-panel-overlay', overlayMods);
 
+    let titleContent = title ? (
+      <SlidingPanelHeader
+        leftBlock={leftBlock}
+        onBackButtonClick={onBackButtonClick}
+        rightBlock={rightBlock}
+        useDefaultLeftBlock={useDefaultLeftBlock}
+      >
+        {title}
+      </SlidingPanelHeader>
+    ) : null;
+
+    let subheaderContent = subheader ? (
+      <div className="ui-sliding-panel__subheader">
+        {subheader}
+      </div>
+    ) : null;
+
+    let footerContent = footer ? (
+      <SlidingPanelFooter>
+        {footer}
+      </SlidingPanelFooter>
+    ) : null;
+
+    const mainContent = [];
+
+    /*
+    ** SlidingPanel migration state. This validation will handle title, subheader and footer
+    ** parameters and will support SlidingPanelHeader and SlidingPanelFooter. React components
+    ** will overides any property definition.
+    **
+    ** We also will encapsulate all components using SlidingPanelContent as an temporary solution.
+    ** After the migration process it will be removed and every child will have to define it, if needed.
+    */
+
+    Children.forEach(children, (child) => {
+      switch (child.type) {
+        case SlidingPanelHeader:
+          titleContent = child;
+          break;
+        case SlidingPanelFooter:
+          footerContent = child;
+          break;
+        case SlidingPanelContent:
+          mainContent.push(child);
+          break;
+        default:
+          mainContent.push(
+            <SlidingPanelContent>
+              { child }
+            </SlidingPanelContent>
+          );
+          break;
+      }
+    });
+
+
     const content = (
       <div className={overlayClassName} onClick={this.handleClickOverlay}>
         <div
@@ -140,30 +197,15 @@ export default class SlidingPanel extends Component {
           style={{ width }}
           {...getDataAttributes(dataAttrs)}
         >
-          {title && (
-            <SlidingPanelHeader
-              leftBlock={leftBlock}
-              onBackButtonClick={onBackButtonClick}
-              rightBlock={rightBlock}
-              useDefaultLeftBlock={useDefaultLeftBlock}
-            >
-              {title}
-            </SlidingPanelHeader>
-          )}
+          {titleContent}
 
-          {subheader && (
-            <div className="ui-sliding-panel__subheader">
-              {subheader}
-            </div>
-          )}
+          {subheaderContent}
 
-          {children}
+          <div className="ui-sliding-panel-content-wrapper">
+            {mainContent}
+          </div>
 
-          {footer && (
-            <SlidingPanelFooter>
-              {footer}
-            </SlidingPanelFooter>
-          )}
+          {footerContent}
         </div>
       </div>
     );

--- a/packages/travix-ui-kit/components/slidingPanel/slidingPanelContent/slidingPanelContent.css
+++ b/packages/travix-ui-kit/components/slidingPanel/slidingPanelContent/slidingPanelContent.css
@@ -1,6 +1,3 @@
 .ui-sliding-panel__content {
-  flex: var(--tx-sliding-panel-content-flex);
-  overflow: var(--tx-sliding-panel-content-overflow);
-  overflow-y: var(--tx-sliding-panel-content-overflow-y);
   padding: 20px;
 }

--- a/packages/travix-ui-kit/tests/unit/slidingPanel/__snapshots__/slidingPanel.spec.js.snap
+++ b/packages/travix-ui-kit/tests/unit/slidingPanel/__snapshots__/slidingPanel.spec.js.snap
@@ -9,9 +9,13 @@ exports[`SlidingPanel #render() calls onTryingToClose function when provided and
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -26,9 +30,13 @@ exports[`SlidingPanel #render() calls onTryingToClose function when provided and
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -43,9 +51,13 @@ exports[`SlidingPanel #render() calls onTryingToClose function when provided via
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -60,9 +72,13 @@ exports[`SlidingPanel #render() calls onTryingToClose function when provided via
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -77,9 +93,13 @@ exports[`SlidingPanel #render() closes the panel when active prop changes to fal
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -94,9 +114,13 @@ exports[`SlidingPanel #render() closes the panel when active prop changes to fal
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -123,7 +147,11 @@ exports[`SlidingPanel #render() do not render footer if prop is not passed or fa
           "width": "480px",
         }
       }
-    />
+    >
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      />
+    </div>
   </div>
 </SlidingPanel>
 `;
@@ -136,11 +164,19 @@ exports[`SlidingPanel #render() enables [data-rel="close"] element provided on t
     class="ui-sliding-panel ui-sliding-panel_active ui-sliding-panel_right"
     style="width: 480px;"
   >
-    <button
-      data-rel="close"
+    <div
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
-    </button>
+      <div
+        class="ui-sliding-panel__content"
+      >
+        <button
+          data-rel="close"
+        >
+          Test
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -153,11 +189,19 @@ exports[`SlidingPanel #render() enables [data-rel="close"] element provided on t
     class="ui-sliding-panel ui-sliding-panel_right"
     style="width: 480px;"
   >
-    <button
-      data-rel="close"
+    <div
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
-    </button>
+      <div
+        class="ui-sliding-panel__content"
+      >
+        <button
+          data-rel="close"
+        >
+          Test
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -171,9 +215,13 @@ exports[`SlidingPanel #render() opens the panel when active prop changes to true
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -188,9 +236,13 @@ exports[`SlidingPanel #render() opens the panel when active prop changes to true
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -205,9 +257,13 @@ exports[`SlidingPanel #render() render active by default and when clicking on th
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -222,9 +278,13 @@ exports[`SlidingPanel #render() render active by default and when clicking on th
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -253,13 +313,17 @@ exports[`SlidingPanel #render() render footer if prop has been passed and it is 
         }
       }
     >
-      <SlidingPanelContent>
-        <div
-          className="ui-sliding-panel__content"
-        >
-          Test
-        </div>
-      </SlidingPanelContent>
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Test
+          </div>
+        </SlidingPanelContent>
+      </div>
       <SlidingPanelFooter>
         <div
           className="ui-sliding-panel__footer"
@@ -303,9 +367,13 @@ exports[`SlidingPanel #render() render header if title prop is passed 1`] = `
       </div>
     </div>
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -344,13 +412,17 @@ exports[`SlidingPanel #render() render with custom subheader 1`] = `
           className="custom-class"
         />
       </div>
-      <SlidingPanelContent>
-        <div
-          className="ui-sliding-panel__content"
-        >
-          Test
-        </div>
-      </SlidingPanelContent>
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Test
+          </div>
+        </SlidingPanelContent>
+      </div>
     </div>
   </div>
 </SlidingPanel>
@@ -378,13 +450,17 @@ exports[`SlidingPanel #render() render with custom width 1`] = `
         }
       }
     >
-      <SlidingPanelContent>
-        <div
-          className="ui-sliding-panel__content"
-        >
-          Test
-        </div>
-      </SlidingPanelContent>
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Test
+          </div>
+        </SlidingPanelContent>
+      </div>
     </div>
   </div>
 </SlidingPanel>
@@ -414,13 +490,17 @@ exports[`SlidingPanel #render() render with default block with back button and a
         }
       }
     >
-      <SlidingPanelContent>
-        <div
-          className="ui-sliding-panel__content"
-        >
-          Test
-        </div>
-      </SlidingPanelContent>
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Test
+          </div>
+        </SlidingPanelContent>
+      </div>
     </div>
   </div>
 </SlidingPanel>
@@ -449,13 +529,17 @@ exports[`SlidingPanel #render() render with default block with back button and a
         }
       }
     >
-      <SlidingPanelContent>
-        <div
-          className="ui-sliding-panel__content"
-        >
-          Test
-        </div>
-      </SlidingPanelContent>
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Test
+          </div>
+        </SlidingPanelContent>
+      </div>
     </div>
   </div>
 </SlidingPanel>
@@ -470,54 +554,16 @@ exports[`SlidingPanel #render() render with default props and mods provided 1`] 
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
-`;
-
-exports[`SlidingPanel #render() render with global mode 1`] = `
-<SlidingPanel
-  closeOnOverlayClick={true}
-  direction="right"
-  global={true}
-  subheader={null}
-  useDefaultLeftBlock={false}
-  width="480px"
->
-  <Global
-    noscroll={false}
-  >
-    <div
-      onClick={[Function]}
-    >
-      <div
-        className="ui-sliding-panel-overlay ui-sliding-panel-overlay_hidden"
-        onClick={[Function]}
-      >
-        <div
-          className="ui-sliding-panel ui-sliding-panel_right"
-          onAnimationEnd={[Function]}
-          style={
-            Object {
-              "width": "480px",
-            }
-          }
-        >
-          <SlidingPanelContent>
-            <div
-              className="ui-sliding-panel__content"
-            >
-              Test
-            </div>
-          </SlidingPanelContent>
-        </div>
-      </div>
-    </div>
-  </Global>
-</SlidingPanel>
 `;
 
 exports[`SlidingPanel #render() render with left direction 1`] = `
@@ -547,13 +593,17 @@ exports[`SlidingPanel #render() render with left direction 1`] = `
         }
       }
     >
-      <SlidingPanelContent>
-        <div
-          className="ui-sliding-panel__content"
-        >
-          Test
-        </div>
-      </SlidingPanelContent>
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Test
+          </div>
+        </SlidingPanelContent>
+      </div>
     </div>
   </div>
 </SlidingPanel>
@@ -581,8 +631,203 @@ exports[`SlidingPanel #render() should render SlidingPanel with provided classNa
           "width": "480px",
         }
       }
-    />
+    >
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      />
+    </div>
   </div>
+</SlidingPanel>
+`;
+
+exports[`SlidingPanel #render() should render slidingPanelContent as fallback if the child is not one 1`] = `
+<SlidingPanel
+  closeOnOverlayClick={true}
+  direction="right"
+  global={false}
+  subheader={null}
+  useDefaultLeftBlock={false}
+  width="480px"
+>
+  <div
+    className="ui-sliding-panel-overlay ui-sliding-panel-overlay_hidden"
+    onClick={[Function]}
+  >
+    <div
+      className="ui-sliding-panel ui-sliding-panel_right"
+      onAnimationEnd={[Function]}
+      style={
+        Object {
+          "width": "480px",
+        }
+      }
+    >
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Test
+          </div>
+        </SlidingPanelContent>
+      </div>
+    </div>
+  </div>
+</SlidingPanel>
+`;
+
+exports[`SlidingPanel #render() should render slidingPanelFooter 1`] = `
+<SlidingPanel
+  closeOnOverlayClick={true}
+  direction="right"
+  global={false}
+  subheader={null}
+  useDefaultLeftBlock={false}
+  width="480px"
+>
+  <div
+    className="ui-sliding-panel-overlay ui-sliding-panel-overlay_hidden"
+    onClick={[Function]}
+  >
+    <div
+      className="ui-sliding-panel ui-sliding-panel_right"
+      onAnimationEnd={[Function]}
+      style={
+        Object {
+          "width": "480px",
+        }
+      }
+    >
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Content
+          </div>
+        </SlidingPanelContent>
+      </div>
+      <SlidingPanelFooter>
+        <div
+          className="ui-sliding-panel__footer"
+        >
+          Footer
+        </div>
+      </SlidingPanelFooter>
+    </div>
+  </div>
+</SlidingPanel>
+`;
+
+exports[`SlidingPanel #render() should render slidingPanelHeader 1`] = `
+<SlidingPanel
+  closeOnOverlayClick={true}
+  direction="right"
+  global={false}
+  subheader={null}
+  useDefaultLeftBlock={false}
+  width="480px"
+>
+  <div
+    className="ui-sliding-panel-overlay ui-sliding-panel-overlay_hidden"
+    onClick={[Function]}
+  >
+    <div
+      className="ui-sliding-panel ui-sliding-panel_right"
+      onAnimationEnd={[Function]}
+      style={
+        Object {
+          "width": "480px",
+        }
+      }
+    >
+      <SlidingPanelHeader>
+        <div
+          className="ui-sliding-panel-header"
+        >
+          <div
+            className="ui-sliding-panel-header__left-block"
+          />
+          <h3
+            className="ui-sliding-panel-header__title"
+          >
+            Title
+          </h3>
+          <div
+            className="ui-sliding-panel-header__right-block"
+          >
+            <button
+              className="ui-sliding-panel-header__close-button"
+              data-rel="close"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      </SlidingPanelHeader>
+      <div
+        className="ui-sliding-panel-content-wrapper"
+      >
+        <SlidingPanelContent>
+          <div
+            className="ui-sliding-panel__content"
+          >
+            Content
+          </div>
+        </SlidingPanelContent>
+      </div>
+    </div>
+  </div>
+</SlidingPanel>
+`;
+
+exports[`SlidingPanel #render() should render with global mode 1`] = `
+<SlidingPanel
+  closeOnOverlayClick={true}
+  direction="right"
+  global={true}
+  subheader={null}
+  useDefaultLeftBlock={false}
+  width="480px"
+>
+  <Global
+    noscroll={false}
+  >
+    <div
+      onClick={[Function]}
+    >
+      <div
+        className="ui-sliding-panel-overlay ui-sliding-panel-overlay_hidden"
+        onClick={[Function]}
+      >
+        <div
+          className="ui-sliding-panel ui-sliding-panel_right"
+          onAnimationEnd={[Function]}
+          style={
+            Object {
+              "width": "480px",
+            }
+          }
+        >
+          <div
+            className="ui-sliding-panel-content-wrapper"
+          >
+            <SlidingPanelContent>
+              <div
+                className="ui-sliding-panel__content"
+              >
+                Test
+              </div>
+            </SlidingPanelContent>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Global>
 </SlidingPanel>
 `;
 
@@ -595,9 +840,13 @@ exports[`SlidingPanel #render() with closeOnOverlayClick=false does not close wh
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>
@@ -612,9 +861,13 @@ exports[`SlidingPanel #render() with closeOnOverlayClick=false does not close wh
     style="width: 480px;"
   >
     <div
-      class="ui-sliding-panel__content"
+      class="ui-sliding-panel-content-wrapper"
     >
-      Test
+      <div
+        class="ui-sliding-panel__content"
+      >
+        Test
+      </div>
     </div>
   </div>
 </div>

--- a/packages/travix-ui-kit/tests/unit/slidingPanel/slidingPanel.spec.js
+++ b/packages/travix-ui-kit/tests/unit/slidingPanel/slidingPanel.spec.js
@@ -2,6 +2,8 @@ import { mount } from 'enzyme';
 import React from 'react';
 import SlidingPanel from '../../../components/slidingPanel/slidingPanel';
 import SlidingPanelContent from '../../../components/slidingPanel/slidingPanelContent/slidingPanelContent';
+import SlidingPanelHeader from '../../../components/slidingPanel/slidingPanelHeader/slidingPanelHeader';
+import SlidingPanelFooter from '../../../components/slidingPanel/slidingPanelFooter/slidingPanelFooter';
 
 jest.useFakeTimers();
 
@@ -351,12 +353,44 @@ describe('SlidingPanel', () => {
       expect(panelElement.hasClass(className)).toEqual(true);
     });
 
-    it('render with global mode', () => {
+    it('should render with global mode', () => {
       const renderTree = mount(
         <SlidingPanel
           global
         >
           <SlidingPanelContent>Test</SlidingPanelContent>
+        </SlidingPanel>
+      );
+
+      expect(renderTree).toMatchSnapshot();
+    });
+
+    it('should render slidingPanelHeader', () => {
+      const renderTree = mount(
+        <SlidingPanel>
+          <SlidingPanelHeader>Title</SlidingPanelHeader>
+          <SlidingPanelContent>Content</SlidingPanelContent>
+        </SlidingPanel>
+      );
+
+      expect(renderTree).toMatchSnapshot();
+    });
+
+    it('should render slidingPanelFooter', () => {
+      const renderTree = mount(
+        <SlidingPanel>
+          <SlidingPanelContent>Content</SlidingPanelContent>
+          <SlidingPanelFooter>Footer</SlidingPanelFooter>
+        </SlidingPanel>
+      );
+
+      expect(renderTree).toMatchSnapshot();
+    });
+
+    it('should render slidingPanelContent as fallback if the child is not one', () => {
+      const renderTree = mount(
+        <SlidingPanel>
+          Test
         </SlidingPanel>
       );
 


### PR DESCRIPTION
### What does this PR do:

Fix SlidingPanel to support the previous implementation, so we will be able to fix everything and then move to new SlidingPanelHeader, SlidingPanelFooter, and SlidingPanelContent components.

It should support all kinds of implementation now.
Eg:

```jsx
<SlidingPanel
  title="title"
  footer="footer"
>
  Content
</SlidingPanel>
```

```jsx
<SlidingPanel
  title="title"
  footer="footer"
>
  <SlidingPanelContent>
    Content
  </SlidingPanelContent>
</SlidingPanel>
```

```jsx
<SlidingPanel>
  <SlidingPanelHeader>
    Title
  </SlidingPanelHeader>

  <SlidingPanelContent>
    Content
  </SlidingPanelContent>

  <SlidingPanelFooter>
    Footer
  </SlidingPanelFooter>
</SlidingPanel>
```

Even weird cases like the following, where SlidingPanelHeader and SlidingPanelFooter will override title and footer props.

```jsx
<SlidingPanel
  title="title"
  footer="footer"
>
  <SlidingPanelHeader>
    Title 2
  </SlidingPanelHeader>

  <SlidingPanelContent>
    Content
  </SlidingPanelContent>

  <SlidingPanelFooter>
    Footer 2
  </SlidingPanelFooter>
</SlidingPanel>
```

Or:

```jsx
<SlidingPanel>
  <SlidingPanelHeader>
    Title 2
  </SlidingPanelHeader>

  <div>
    Another content
  </div>

  <SlidingPanelContent>
    Content
  </SlidingPanelContent>

  <SlidingPanelFooter>
    Footer 2
  </SlidingPanelFooter>
</SlidingPanel>
```

### Where should the reviewer start:

Diff.