### PR TITLE
Use specific keyframes names for sliding panel

### DIFF
--- a/packages/travix-ui-kit/components/slidingPanel/slidingPanel.css
+++ b/packages/travix-ui-kit/components/slidingPanel/slidingPanel.css
@@ -34,24 +34,24 @@
 }
 
 .ui-sliding-panel_right {
-  animation: sidePanelClose 195ms ease-in-out 0s 1 both;
+  animation: uiKitSidePanelClose 195ms ease-in-out 0s 1 both;
   left: var(--tx-sliding-panel-right-direction-left);
   right: var(--tx-sliding-panel-right-direction-right);
 
 }
 
 .ui-sliding-panel_right.ui-sliding-panel_active  {
-  animation: sidePanelOpen 195ms ease-in-out 0s 1 both;
+  animation: uiKitSidePanelOpen 195ms ease-in-out 0s 1 both;
 }
 
 .ui-sliding-panel_left {
-  animation: sidePanelLeftClose 195ms ease-in-out 0s 1 both;
+  animation: uiKitsidePanelLeftClose 195ms ease-in-out 0s 1 both;
   left: var(--tx-sliding-panel-left-direction-left);
   right: var(--tx-sliding-panel-left-direction-right);
 }
 
 .ui-sliding-panel_left.ui-sliding-panel_active  {
-  animation: sidePanelLeftOpen 195ms ease-in-out 0s 1 both;
+  animation: uiKitSidePanelLeftOpen 195ms ease-in-out 0s 1 both;
 }
 
 .ui-sliding-panel-content-wrapper {
@@ -60,7 +60,7 @@
   overflow-y: var(--tx-sliding-panel-content-overflow-y);
 }
 
-@keyframes sidePanelOpen {
+@keyframes uiKitSidePanelOpen {
   0% {
     transform: translateX(100%);
   }
@@ -69,7 +69,7 @@
   }
 }
 
-@keyframes sidePanelClose {
+@keyframes uiKitSidePanelClose {
   0% {
     transform: translateX(0);
   }
@@ -78,7 +78,7 @@
   }
 }
 
-@keyframes sidePanelLeftOpen {
+@keyframes uiKitSidePanelLeftOpen {
   0% {
     transform: translateX(-100%);
   }
@@ -87,7 +87,7 @@
   }
 }
 
-@keyframes sidePanelLeftClose {
+@keyframes uiKitsidePanelLeftClose {
   0% {
     transform: translateX(0);
   }

--- a/packages/travix-ui-kit/components/slidingPanel/slidingPanel.css
+++ b/packages/travix-ui-kit/components/slidingPanel/slidingPanel.css
@@ -45,7 +45,7 @@
 }
 
 .ui-sliding-panel_left {
-  animation: uiKitsidePanelLeftClose 195ms ease-in-out 0s 1 both;
+  animation: uiKitSidePanelLeftClose 195ms ease-in-out 0s 1 both;
   left: var(--tx-sliding-panel-left-direction-left);
   right: var(--tx-sliding-panel-left-direction-right);
 }
@@ -87,7 +87,7 @@
   }
 }
 
-@keyframes uiKitsidePanelLeftClose {
+@keyframes uiKitSidePanelLeftClose {
   0% {
     transform: translateX(0);
   }

--- a/packages/travix-ui-kit/components/spinner/spinner.scss
+++ b/packages/travix-ui-kit/components/spinner/spinner.scss
@@ -1,6 +1,6 @@
 
 .ui-spinner {
-  animation: rotation infinite 0.7s;
+  animation: uiKitSpinnerRotation infinite 0.7s;
   display: inline-block;
 }
 
@@ -46,7 +46,7 @@
   stroke: var(--tx-spinner-color-lighter);
 }
 
-@keyframes bouncedelay {
+@keyframes uiKitSpinnerBouncedelay {
   0%, 80%, 100% {
     transform: scale(0.0);
   } 40% {
@@ -54,7 +54,7 @@
   }
 }
 
-@keyframes rotation {
+@keyframes uiKitSpinnerRotation {
   0% {
     animation-timing-function: steps(1, end);
     transform: rotate(0deg);

--- a/packages/travix-ui-kit/components/spinner/spinner.scss
+++ b/packages/travix-ui-kit/components/spinner/spinner.scss
@@ -46,14 +46,6 @@
   stroke: var(--tx-spinner-color-lighter);
 }
 
-@keyframes uiKitSpinnerBouncedelay {
-  0%, 80%, 100% {
-    transform: scale(0.0);
-  } 40% {
-    transform: scale(1.0);
-  }
-}
-
 @keyframes uiKitSpinnerRotation {
   0% {
     animation-timing-function: steps(1, end);


### PR DESCRIPTION
### What does this PR do:

Change keyframes to be specific for ui-kit. Reason: the same keyframes names in RWD which are overriding ui-kit ones and breaking them.

### Where should the reviewer start:

Diff.