### PR TITLE
Checkbox: move data attrs to input instead of label

### DIFF
--- a/packages/travix-ui-kit/components/checkbox/checkbox.js
+++ b/packages/travix-ui-kit/components/checkbox/checkbox.js
@@ -27,11 +27,11 @@ function Checkbox(props) {
 
   return (
     <label
-      {...dataAttributes}
       className={classNames}
       htmlFor={name}
     >
       <input
+        {...dataAttributes}
         aria-checked={checked}
         checked={checked}
         disabled={disabled}

--- a/packages/travix-ui-kit/components/checkbox/checkbox.md
+++ b/packages/travix-ui-kit/components/checkbox/checkbox.md
@@ -8,9 +8,11 @@ Basic checkbox:
         <Checkbox
           name="checkboxTest4"
           checked={state.value}
-          onChange={() => {setState({value: !state.value})}}
-          inputAttr={{role: "radio"}}>
+          onChange={() => {setState({value: !state.value})}}>
           can toggle
-        </Checkbox>
+        </Checkbox><br/>
+        <Checkbox checked dataAttrs={{'gtm-id': 'test-checkbox'}} name="checkboxTest5" onChange={() => {alert('checked')}}>
+          with data attrs
+        </Checkbox><br/>
       </div>
     </div>

--- a/packages/travix-ui-kit/components/checkbox/checkbox.md
+++ b/packages/travix-ui-kit/components/checkbox/checkbox.md
@@ -11,7 +11,11 @@ Basic checkbox:
           onChange={() => {setState({value: !state.value})}}>
           can toggle
         </Checkbox><br/>
-        <Checkbox checked dataAttrs={{'gtm-id': 'test-checkbox'}} name="checkboxTest5" onChange={() => {alert('checked')}}>
+        <Checkbox
+          checked
+          dataAttrs={{'gtm-id': 'test-checkbox'}}
+          name="checkboxTest5"
+          onChange={() => {alert('checked')}}>
           with data attrs
         </Checkbox><br/>
       </div>

--- a/packages/travix-ui-kit/tests/unit/checkbox/__snapshots__/checkbox.spec.js.snap
+++ b/packages/travix-ui-kit/tests/unit/checkbox/__snapshots__/checkbox.spec.js.snap
@@ -41,6 +41,28 @@ exports[`Checkbox #render() should render checkbox 1`] = `
 </label>
 `;
 
+exports[`Checkbox #render() should render checkbox with dataAttrs 1`] = `
+<label
+  className="ui-checkbox test-class"
+  htmlFor=""
+>
+  <input
+    aria-checked={false}
+    checked={false}
+    data-gtm-id="test-checkbox"
+    disabled={false}
+    id=""
+    onChange={[Function]}
+    readOnly={false}
+    role="radio"
+    type="checkbox"
+  />
+  <span
+    className="ui-checkbox__text"
+  />
+</label>
+`;
+
 exports[`Checkbox #render() should render checkbox with provided className 1`] = `
 <label
   className="ui-checkbox test-class"

--- a/packages/travix-ui-kit/tests/unit/checkbox/checkbox.spec.js
+++ b/packages/travix-ui-kit/tests/unit/checkbox/checkbox.spec.js
@@ -61,5 +61,13 @@ describe('Checkbox', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render checkbox with dataAttrs', () => {
+      const wrapper = shallow(
+        <Checkbox className="test-class" dataAttrs={{ 'gtm-id': 'test-checkbox' }} onChange={onChange} />
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do:
For Checkbox, GA complaining they cannot track the inputs in the checkboxes since we are passing data attributes to the label tag. 
This PR moves data attrr to input tag itself.
Updates unit tests and demo. In md file, 1 obsolete prop also removed.

### Where should the reviewer start:
`packages/travix-ui-kit/components/checkbox/checkbox.js`