### PR TITLE
Checkbox, RadioButton: Extend data attrs to pass in root

### DIFF
--- a/packages/travix-ui-kit/components/checkbox/checkbox.js
+++ b/packages/travix-ui-kit/components/checkbox/checkbox.js
@@ -85,7 +85,6 @@ Checkbox.propTypes = {
     PropTypes.object,
   ]),
 
-
   /**
    * Current activity state of the checkbox.
    */

--- a/packages/travix-ui-kit/components/checkbox/checkbox.js
+++ b/packages/travix-ui-kit/components/checkbox/checkbox.js
@@ -17,10 +17,13 @@ function Checkbox(props) {
     className,
     dataAttrs = {},
     disabled,
+    inputDataAttrs = {},
     name,
     onChange,
   } = props;
+
   const dataAttributes = getDataAttributes(dataAttrs);
+  const inputDataAttributes = getDataAttributes(inputDataAttrs);
   const mods = props.mods ? props.mods.slice() : [];
   disabled && mods.push('is-disabled');
   const classNames = classnames(getClassNamesWithMods('ui-checkbox', mods), className);
@@ -32,6 +35,7 @@ function Checkbox(props) {
       htmlFor={name}
     >
       <input
+        {...inputDataAttributes}
         aria-checked={checked}
         checked={checked}
         disabled={disabled}
@@ -74,17 +78,26 @@ Checkbox.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Data attribute. You can use it to set up any custom data-* attribute.
+   * Data attribute. You can use it to set up any custom data-* attribute for label.
    */
   dataAttrs: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.object,
   ]),
 
+
   /**
    * Current activity state of the checkbox.
    */
   disabled: PropTypes.bool,
+
+  /**
+   * Data attribute. You can use it to set up any custom data-* attribute for input.
+   */
+  inputDataAttrs: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.object,
+  ]),
 
   /**
    * You can provide set of custom modifications.

--- a/packages/travix-ui-kit/components/radioButton/radioButton.js
+++ b/packages/travix-ui-kit/components/radioButton/radioButton.js
@@ -18,10 +18,12 @@ function RadioButton(props) {
     dataAttrs = {},
     disabled,
     id,
+    inputDataAttrs,
     name,
     onChange,
   } = props;
   const dataAttributes = getDataAttributes(dataAttrs);
+  const inputDataAttributes = getDataAttributes(inputDataAttrs);
   const mods = props.mods ? props.mods.slice() : [];
 
   if (disabled) {
@@ -33,6 +35,7 @@ function RadioButton(props) {
   return (
     <div className={classNames} {...dataAttributes}>
       <input
+        {...inputDataAttributes}
         checked={checked}
         className="ui-radio__input-radio"
         disabled={disabled}
@@ -75,7 +78,7 @@ RadioButton.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Data attribute. You can use it to set up any custom data-* attribute.
+   * Data attribute. You can use it to set up any custom data-* attribute (for root element).
    */
   dataAttrs: PropTypes.oneOfType([
     PropTypes.bool,
@@ -91,6 +94,14 @@ RadioButton.propTypes = {
    * Identifier for Radio Button element.
    */
   id: PropTypes.string.isRequired,
+
+  /**
+   * Data attribute. You can use it to set up any custom data-* attribute for input.
+   */
+  inputDataAttrs: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.object,
+  ]),
 
   /**
    * Represents the element's name.

--- a/packages/travix-ui-kit/tests/unit/checkbox/__snapshots__/checkbox.spec.js.snap
+++ b/packages/travix-ui-kit/tests/unit/checkbox/__snapshots__/checkbox.spec.js.snap
@@ -41,6 +41,50 @@ exports[`Checkbox #render() should render checkbox 1`] = `
 </label>
 `;
 
+exports[`Checkbox #render() should render checkbox with dataAttrs for the input 1`] = `
+<label
+  className="ui-checkbox test-class"
+  htmlFor=""
+>
+  <input
+    aria-checked={false}
+    checked={false}
+    data-my-attr-for-input="some-attr-for-input"
+    disabled={false}
+    id=""
+    onChange={[Function]}
+    readOnly={false}
+    role="radio"
+    type="checkbox"
+  />
+  <span
+    className="ui-checkbox__text"
+  />
+</label>
+`;
+
+exports[`Checkbox #render() should render checkbox with dataAttrs for the label 1`] = `
+<label
+  className="ui-checkbox test-class"
+  data-my-attr="some-attr"
+  htmlFor=""
+>
+  <input
+    aria-checked={false}
+    checked={false}
+    disabled={false}
+    id=""
+    onChange={[Function]}
+    readOnly={false}
+    role="radio"
+    type="checkbox"
+  />
+  <span
+    className="ui-checkbox__text"
+  />
+</label>
+`;
+
 exports[`Checkbox #render() should render checkbox with provided className 1`] = `
 <label
   className="ui-checkbox test-class"

--- a/packages/travix-ui-kit/tests/unit/checkbox/checkbox.spec.js
+++ b/packages/travix-ui-kit/tests/unit/checkbox/checkbox.spec.js
@@ -61,5 +61,25 @@ describe('Checkbox', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render checkbox with dataAttrs for the label', () => {
+      const wrapper = shallow(
+        <Checkbox className="test-class" dataAttrs={{ 'my-attr': 'some-attr' }} onChange={onChange} />
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render checkbox with dataAttrs for the input', () => {
+      const wrapper = shallow(
+        <Checkbox
+          className="test-class"
+          inputDataAttrs={{ 'my-attr-for-input': 'some-attr-for-input' }}
+          onChange={onChange}
+        />
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });

--- a/packages/travix-ui-kit/tests/unit/radioButton/__snapshots__/radioButton.spec.js.snap
+++ b/packages/travix-ui-kit/tests/unit/radioButton/__snapshots__/radioButton.spec.js.snap
@@ -96,6 +96,56 @@ exports[`Radio Button #render() should render radio button 1`] = `
 </div>
 `;
 
+exports[`Radio Button #render() should render radio button with dataAttrs for input 1`] = `
+<div
+  className="ui-radio test-class"
+>
+  <input
+    checked={false}
+    className="ui-radio__input-radio"
+    data-my-attr-for-input="some-attr-for-input"
+    disabled={false}
+    id="radio1"
+    onChange={[Function]}
+    readOnly={false}
+    type="radio"
+  />
+  <label
+    aria-checked={false}
+    className="ui-radio__label"
+    htmlFor="radio1"
+    role="radio"
+  >
+    Radio 1
+  </label>
+</div>
+`;
+
+exports[`Radio Button #render() should render radio button with dataAttrs for root element 1`] = `
+<div
+  className="ui-radio test-class"
+  data-my-attr="some-attr"
+>
+  <input
+    checked={false}
+    className="ui-radio__input-radio"
+    disabled={false}
+    id="radio1"
+    onChange={[Function]}
+    readOnly={false}
+    type="radio"
+  />
+  <label
+    aria-checked={false}
+    className="ui-radio__label"
+    htmlFor="radio1"
+    role="radio"
+  >
+    Radio 1
+  </label>
+</div>
+`;
+
 exports[`Radio Button #render() should render radio button with provided className 1`] = `
 <div
   className="ui-radio test-class"

--- a/packages/travix-ui-kit/tests/unit/radioButton/radioButton.spec.js
+++ b/packages/travix-ui-kit/tests/unit/radioButton/radioButton.spec.js
@@ -58,5 +58,30 @@ describe('Radio Button', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render radio button with dataAttrs for root element', () => {
+      const wrapper = shallow(
+        <RadioButton className="test-class" dataAttrs={{ 'my-attr': 'some-attr' }} id="radio1" onChange={onChange}>
+          Radio 1
+        </RadioButton>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render radio button with dataAttrs for input', () => {
+      const wrapper = shallow(
+        <RadioButton
+          className="test-class"
+          id="radio1"
+          inputDataAttrs={{ 'my-attr-for-input': 'some-attr-for-input' }}
+          onChange={onChange}
+        >
+          Radio 1
+        </RadioButton>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do:

This PR adds possibility to pass data attributes to input directly without breaking an existing API (still is possible to pass dataAttrs to the wrapper).
Components affected: Checkbox, RadioButton.

### Where should the reviewer start:

`packages/travix-ui-kit/components/checkbox/checkbox.js`
`packages/travix-ui-kit/components/radioButton/radioButton.js`