### PR TITLE
[travix-ui-kit] Fix moveToMonth method in Calendar

### DIFF
--- a/packages/travix-ui-kit/components/calendar/calendar.js
+++ b/packages/travix-ui-kit/components/calendar/calendar.js
@@ -137,8 +137,9 @@ export default class Calendar extends Component {
     const { onNavNextMonth, onNavPreviousMonth } = this.props;
 
     this.setState(({ renderDate }) => {
-      renderDate.setMonth(renderDate.getMonth() + (direction === CALENDAR_MOVE_TO_PREVIOUS ? -1 : 1));
-      return { renderDate };
+      const newDate = new Date(renderDate);
+      newDate.setMonth(renderDate.getMonth() + (direction === CALENDAR_MOVE_TO_PREVIOUS ? -1 : 1));
+      return { renderDate: newDate };
     }, () => {
       if ((direction === CALENDAR_MOVE_TO_PREVIOUS) && onNavPreviousMonth) {
         onNavPreviousMonth(this.state.renderDate);

--- a/packages/travix-ui-kit/tests/unit/calendar/calendar.normal.spec.js
+++ b/packages/travix-ui-kit/tests/unit/calendar/calendar.normal.spec.js
@@ -429,18 +429,20 @@ describe('Calendar (normal mode)', () => {
         <Calendar initialDates={['2017-01-01']} />
       );
 
-      const daysView = wrapper.find('Days').at(1);
       const nextBtn = wrapper.find('.ui-calendar-days__next-month');
       const previousBtn = wrapper.find('.ui-calendar-days__previous-month');
 
       previousBtn.simulate('click');
-      expect(daysView.props().renderDate.getMonth()).toEqual(11);
+      wrapper.update();
+      expect(wrapper.find('Days').at(1).props().renderDate.getMonth()).toEqual(11);
 
       nextBtn.simulate('click');
-      expect(daysView.props().renderDate.getMonth()).toEqual(0);
+      wrapper.update();
+      expect(wrapper.find('Days').at(1).props().renderDate.getMonth()).toEqual(0);
 
       nextBtn.simulate('click');
-      expect(daysView.props().renderDate.getMonth()).toEqual(1);
+      wrapper.update();
+      expect(wrapper.find('Days').at(1).props().renderDate.getMonth()).toEqual(1);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do:

Fix issue with `setState` call in `moveToMonth` method of Calendar. Callback mutate previous state on each call.

### Where should the reviewer start:

Diff