### PR TITLE
Added data attrs for label

### DIFF
--- a/packages/travix-ui-kit/components/radioButton/radioButton.js
+++ b/packages/travix-ui-kit/components/radioButton/radioButton.js
@@ -35,7 +35,7 @@ function RadioButton(props) {
   const classNames = classnames(getClassNamesWithMods('ui-radio', mods), className);
 
   return (
-    <div className={classNames} {...dataAttributes}>
+    <div {...dataAttributes} className={classNames}>
       <input
         {...inputDataAttributes}
         checked={checked}
@@ -47,7 +47,13 @@ function RadioButton(props) {
         readOnly={!onChange}
         type="radio"
       />
-      <label aria-checked={checked} className="ui-radio__label" htmlFor={id} role="radio" {...labelDataAttributes}>
+      <label
+        {...labelDataAttributes}
+        aria-checked={checked}
+        className="ui-radio__label"
+        htmlFor={id}
+        role="radio"
+      >
         {children}
       </label>
     </div>

--- a/packages/travix-ui-kit/components/radioButton/radioButton.js
+++ b/packages/travix-ui-kit/components/radioButton/radioButton.js
@@ -19,11 +19,13 @@ function RadioButton(props) {
     disabled,
     id,
     inputDataAttrs,
+    labelDataAttrs,
     name,
     onChange,
   } = props;
   const dataAttributes = getDataAttributes(dataAttrs);
   const inputDataAttributes = getDataAttributes(inputDataAttrs);
+  const labelDataAttributes = getDataAttributes(labelDataAttrs);
   const mods = props.mods ? props.mods.slice() : [];
 
   if (disabled) {
@@ -45,7 +47,7 @@ function RadioButton(props) {
         readOnly={!onChange}
         type="radio"
       />
-      <label aria-checked={checked} className="ui-radio__label" htmlFor={id} role="radio">
+      <label aria-checked={checked} className="ui-radio__label" htmlFor={id} role="radio" {...labelDataAttributes}>
         {children}
       </label>
     </div>
@@ -99,6 +101,14 @@ RadioButton.propTypes = {
    * Data attribute. You can use it to set up any custom data-* attribute for input.
    */
   inputDataAttrs: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.object,
+  ]),
+
+  /**
+   * Data attribute. You can use it to set up any custom data-* attribute for label.
+   */
+  labelDataAttrs: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.object,
   ]),

--- a/packages/travix-ui-kit/tests/unit/radioButton/__snapshots__/radioButton.spec.js.snap
+++ b/packages/travix-ui-kit/tests/unit/radioButton/__snapshots__/radioButton.spec.js.snap
@@ -121,6 +121,31 @@ exports[`Radio Button #render() should render radio button with dataAttrs for in
 </div>
 `;
 
+exports[`Radio Button #render() should render radio button with dataAttrs for label 1`] = `
+<div
+  className="ui-radio test-class"
+>
+  <input
+    checked={false}
+    className="ui-radio__input-radio"
+    disabled={false}
+    id="radio1"
+    onChange={[Function]}
+    readOnly={false}
+    type="radio"
+  />
+  <label
+    aria-checked={false}
+    className="ui-radio__label"
+    data-my-attr-for-label="some-attr-for-label"
+    htmlFor="radio1"
+    role="radio"
+  >
+    Radio 1
+  </label>
+</div>
+`;
+
 exports[`Radio Button #render() should render radio button with dataAttrs for root element 1`] = `
 <div
   className="ui-radio test-class"

--- a/packages/travix-ui-kit/tests/unit/radioButton/radioButton.spec.js
+++ b/packages/travix-ui-kit/tests/unit/radioButton/radioButton.spec.js
@@ -83,5 +83,20 @@ describe('Radio Button', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render radio button with dataAttrs for label', () => {
+      const wrapper = shallow(
+        <RadioButton
+          className="test-class"
+          id="radio1"
+          labelDataAttrs={{ 'my-attr-for-label': 'some-attr-for-label' }}
+          onChange={onChange}
+        >
+          Radio 1
+        </RadioButton>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do:

Adds data attrs for props for label to be able to point to the label in e2e test.

### Where should the reviewer start:

See the diff

### RELATED PRs (to be merged after this one is released):

e2e: https://bitbucket.org/xivart/rwd_webdriver/pull-requests/97
airhelp: https://bitbucket.org/xivart/travix.app.airhelp/pull-requests/64