### PR TITLE
Change proptypes for title, subtitle and logoLabel props in selectionblock

### DIFF
--- a/packages/travix-ui-kit/components/selectionBlock/selectionBlock.js
+++ b/packages/travix-ui-kit/components/selectionBlock/selectionBlock.js
@@ -96,15 +96,15 @@ SelectionBlock.propTypes = {
   /**
    * The logo label.
    */
-  logoLabel: PropTypes.string,
+  logoLabel: PropTypes.node,
   /**
    * The selection block subtitle.
    */
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
   /**
    * The selection block title.
    */
-  title: PropTypes.string,
+  title: PropTypes.node,
   /**
    * The selection block type.
    */

--- a/packages/travix-ui-kit/components/selectionBlock/selectionBlock.md
+++ b/packages/travix-ui-kit/components/selectionBlock/selectionBlock.md
@@ -11,16 +11,16 @@ SelectionBlock:
       <div style={{ paddingBottom: '20px', display: 'flex' }}>
         <div>
           <RadioButton
-            checked={state.type === 'horizontal'} 
-            id="selectionBlockTypeHorizontal" 
+            checked={state.type === 'horizontal'}
+            id="selectionBlockTypeHorizontal"
             name="selectionBlockType"
             onChange={() => setState({ type: 'horizontal' })}
           >
             type: horizontal
           </RadioButton>
           <RadioButton
-            checked={state.type === 'vertical'} 
-            id="selectionBlockTypeVertical" 
+            checked={state.type === 'vertical'}
+            id="selectionBlockTypeVertical"
             name="selectionBlockType"
             onChange={() => setState({ type: 'vertical' })}
           >
@@ -30,8 +30,8 @@ SelectionBlock:
         <div>
           <RadioButton
             disabled={state.type === 'vertical'}
-            checked={state.align === 'start'} 
-            id="selectionBlockAlignStart" 
+            checked={state.align === 'start'}
+            id="selectionBlockAlignStart"
             name="selectionBlockAlign"
             onChange={() => setState({ align: 'start' })}
           >
@@ -39,8 +39,8 @@ SelectionBlock:
           </RadioButton>
           <RadioButton
             disabled={state.type === 'vertical'}
-            checked={state.align === 'center'} 
-            id="selectionBlockAlignCenter" 
+            checked={state.align === 'center'}
+            id="selectionBlockAlignCenter"
             name="selectionBlockAlign"
             onChange={() => setState({ align: 'center' })}
           >
@@ -48,8 +48,8 @@ SelectionBlock:
           </RadioButton>
           <RadioButton
             disabled={state.type === 'vertical'}
-            checked={state.align === 'end'} 
-            id="selectionBlockAlignEnd" 
+            checked={state.align === 'end'}
+            id="selectionBlockAlignEnd"
             name="selectionBlockAlign"
             onChange={() => setState({ align: 'end' })}
           >
@@ -61,16 +61,16 @@ SelectionBlock:
         align={state.align}
         icon=<span style={{ fontSize: '60px', color: state.iconColor }}>{!state.selectedCard ? '☻' : '☺'}</span>
         logo=<img style={{ height: '30px' }} src="https://www.travix.com/wp-content/uploads/2015/09/travix-logo_blue.png" />
-        logoLabel="Powered by"
+        logoLabel={<span>Powered by</span>}
         subtitle="Subtitle Example"
         title="Title Example"
         type={state.type}
       >
         <div style={{ display: state.type === 'horizontal' ? 'block' : 'flex' }} >
           {[0,1].map(item =>
-            <Card 
-              checked={state.selectedCard === item} 
-              showIcon hovering 
+            <Card
+              checked={state.selectedCard === item}
+              showIcon hovering
               onClick={() => setState({ selectedCard: item, iconColor: item ? 'var(--tx-generic-color-negative-light)' : 'var(--tx-generic-color-active)' })}
             >
               <div style={{ background: 'var(--tx-generic-color-secondary)', padding: '50px', borderRadius: '8px' }}>

--- a/packages/travix-ui-kit/tests/unit/selectionBlock/__snapshots__/selectionBlock.spec.js.snap
+++ b/packages/travix-ui-kit/tests/unit/selectionBlock/__snapshots__/selectionBlock.spec.js.snap
@@ -98,3 +98,74 @@ exports[`SelectionBlock #render() should render selection block with logo and ic
   </div>
 </div>
 `;
+
+exports[`SelectionBlock #render() should render selection block with logoLabel as a node 1`] = `
+<div
+  className="ui-selection-block ui-selection-block_align-center"
+>
+  <div
+    className="ui-selection-block__section"
+  >
+    <header
+      className="ui-selection-block__header"
+    >
+      <div
+        className="ui-selection-block__titles"
+      >
+        <div
+          className="ui-selection-block__icon"
+        >
+          <span>
+            ☻
+          </span>
+        </div>
+        <h2
+          className="ui-selection-block__title"
+        >
+          Title
+        </h2>
+        <h5
+          className="ui-selection-block__subtitle"
+        >
+          Subtitle
+        </h5>
+      </div>
+      <div
+        className="ui-selection-block__logo"
+      >
+        <span
+          className="ui-selection-block__logo-label"
+        >
+          <span>
+            Powered by
+          </span>
+        </span>
+        <img
+          src="https://www.travix.com/wp-content/uploads/2015/09/travix-logo_blue.png"
+        />
+      </div>
+    </header>
+    <div
+      className="ui-selection-block__body"
+    >
+      <div>
+        body
+      </div>
+    </div>
+  </div>
+  <div
+    className="ui-selection-block__logo"
+  >
+    <span
+      className="ui-selection-block__logo-label"
+    >
+      <span>
+        Powered by
+      </span>
+    </span>
+    <img
+      src="https://www.travix.com/wp-content/uploads/2015/09/travix-logo_blue.png"
+    />
+  </div>
+</div>
+`;

--- a/packages/travix-ui-kit/tests/unit/selectionBlock/selectionBlock.spec.js
+++ b/packages/travix-ui-kit/tests/unit/selectionBlock/selectionBlock.spec.js
@@ -31,5 +31,21 @@ describe('SelectionBlock', () => {
 
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render selection block with logoLabel as a node', () => {
+      const wrapper = shallow(
+        <SelectionBlock
+          icon={<span>☻</span>}
+          logo={<img src="https://www.travix.com/wp-content/uploads/2015/09/travix-logo_blue.png" />}
+          logoLabel={<span>Powered by</span>}
+          subtitle="Subtitle"
+          title="Title"
+        >
+          <div>body</div>
+        </SelectionBlock>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do:

This PR replaces `title`, `subtitle` and `logoLabel` proptypes in `selectionBlock` from string to node.
In our insurance widget (and SP actually) we created wrapper for L10ns to make it easier to use. L10ns wrapper returns any react element (such as span, div, etc). For now there are many warnings related to these things in console. After merging these changes everyone who uses this component will be able to use nodes instead of strings



### Where should the reviewer start:

see diff