### PR TITLE
fix remove child for global

### DIFF
--- a/packages/travix-ui-kit/components/global/global.js
+++ b/packages/travix-ui-kit/components/global/global.js
@@ -49,7 +49,7 @@ class Global extends Component {
     }
   }
 
-  handleClick = (e) => { 
+  handleClick = (e) => {
     e.stopPropagation();
   }
 

--- a/packages/travix-ui-kit/components/global/global.js
+++ b/packages/travix-ui-kit/components/global/global.js
@@ -49,13 +49,15 @@ class Global extends Component {
     }
   }
 
-  handleClick = (e) => {
+  handleClick = (e) => { 
     e.stopPropagation();
   }
 
   componentWillUnmount() {
     this.toggleGlobalNoscroll(false);
-    global.window.document.body.removeChild(this.target);
+
+    const body = global.window.document.body;
+    body && removeChild(this.target);
   }
 
   render() {

--- a/packages/travix-ui-kit/components/global/global.js
+++ b/packages/travix-ui-kit/components/global/global.js
@@ -57,7 +57,7 @@ class Global extends Component {
     this.toggleGlobalNoscroll(false);
 
     const body = global.window.document.body;
-    body && removeChild(this.target);
+    body && body.removeChild(this.target);
   }
 
   render() {


### PR DESCRIPTION
### What does this PR do:

In our logging system we have this kind of errors in `global.js`:
`Cannot read property 'removeChild' of null`

I don't know the reason exactly and cannot reproduce this weird error locally and on production. But we need to fix it. (Sliding panel with `global.js` works as expected in all cases)