### PR TITLE
[CFE-20096] Fix <LoadingOverlay /> overflow prop.

### DIFF
--- a/packages/travix-ui-kit/components/loadingOverlay/loadingOverlay.css
+++ b/packages/travix-ui-kit/components/loadingOverlay/loadingOverlay.css
@@ -2,7 +2,6 @@
 
 .ui-loading-overlay {
   border-radius: 8px;
-  overflow: hidden;
   position: relative;
 }
 
@@ -11,6 +10,7 @@
   display: flex;
   height: 100%;
   justify-content: center;
+  overflow: hidden;
   position: absolute;
   width: 100%;
   z-index: 100;

--- a/packages/travix-ui-kit/components/loadingOverlay/loadingOverlay.css
+++ b/packages/travix-ui-kit/components/loadingOverlay/loadingOverlay.css
@@ -1,7 +1,6 @@
 @value messageMargin: 8px;
 
 .ui-loading-overlay {
-  border-radius: 8px;
   position: relative;
 }
 
@@ -10,7 +9,6 @@
   display: flex;
   height: 100%;
   justify-content: center;
-  overflow: hidden;
   position: absolute;
   width: 100%;
   z-index: 100;
@@ -58,6 +56,7 @@
 .ui-loading-overlay_loading .ui-loading-overlay__content:before {
   background: var(--tx-generic-color-secondary-light);
   bottom: 0;
+  border-radius: 8px;
   content: "";
   left: 0;
   position: absolute;


### PR DESCRIPTION
### What does this PR do:

`<LoadingOverlay />` element would wrap its children (the content) in a `<div>` that had `overflow: hidden;` all the time. This would make things like `<select>`'s break when open (e.g. https://travix.atlassian.net/browse/CFE-20096 ). The only reason I could find for this `overflow: hidden` prop was for the border-radius to be displayed properly when the `loading` prop is `true`, so I moved those styles to its proper element.

### Where should the reviewer start:

Minor change, so just check the diff.