### PR TITLE
Update check for value of renderDate with minLimit and maxLimit

### DIFF
--- a/packages/travix-ui-kit/components/calendar/calendar.js
+++ b/packages/travix-ui-kit/components/calendar/calendar.js
@@ -31,7 +31,7 @@ function processProps(props) {
   const { initialDates, maxDate, minDate, selectionType, multiplemode } = props;
   const maxLimit = maxDate ? normalizeDate(new Date(maxDate), 23, 59, 59, 999) : null;
 
-  const renderDate = (initialDates && initialDates.length && initialDates[0]) ? new Date(initialDates[0]) : new Date();
+  let renderDate = (initialDates && initialDates.length && initialDates[0]) ? new Date(initialDates[0]) : new Date();
   normalizeDate(renderDate);
 
   let minLimit = minDate ? normalizeDate(new Date(minDate)) : null;
@@ -71,28 +71,10 @@ function processProps(props) {
   }
 
   /** If the renderDate is not between any of the minLimit and/or maxDate, we need to redefine it. */
-  if (minLimit) {
-    const renderDateYear = renderDate.getFullYear();
-    const minLimitYear = minLimit.getFullYear();
-
-    if (renderDateYear < minLimitYear) {
-      renderDate.setFullYear(minLimitYear);
-    }
-
-    if (renderDateYear === minLimitYear && renderDate.getMonth() < minLimit.getMonth()) {
-      renderDate.setMonth(minLimit.getMonth());
-    }
-  } else if (maxLimit) {
-    const renderDateYear = renderDate.getFullYear();
-    const maxLimitYear = maxLimit.getFullYear();
-
-    if (renderDateYear > maxLimitYear) {
-      renderDate.setFullYear(maxLimitYear);
-    }
-
-    if (renderDateYear === maxLimitYear && renderDate.getMonth() > maxLimit.getMonth()) {
-      renderDate.setMonth(maxLimit.getMonth());
-    }
+  if (minLimit && (renderDate.getTime() < minLimit.getTime())) {
+    renderDate = minLimit;
+  } else if (maxLimit && (renderDate.getTime() > maxLimit.getTime())) {
+    renderDate = maxLimit;
   }
 
   return {

--- a/packages/travix-ui-kit/components/calendar/calendar.js
+++ b/packages/travix-ui-kit/components/calendar/calendar.js
@@ -71,16 +71,28 @@ function processProps(props) {
   }
 
   /** If the renderDate is not between any of the minLimit and/or maxDate, we need to redefine it. */
-  if (minLimit &&
-    (renderDate.getFullYear() <= minLimit.getFullYear()) &&
-    (renderDate.getMonth() < minLimit.getMonth())
-  ) {
-    renderDate.setMonth(minLimit.getMonth());
-  } else if (maxLimit &&
-      (renderDate.getFullYear() <= maxLimit.getFullYear()) &&
-      (renderDate.getMonth() > maxLimit.getMonth())
-  ) {
-    renderDate.setMonth(maxLimit.getMonth());
+  if (minLimit) {
+    const renderDateYear = renderDate.getFullYear();
+    const minLimitYear = minLimit.getFullYear();
+
+    if (renderDateYear < minLimitYear) {
+      renderDate.setFullYear(minLimitYear);
+    }
+
+    if (renderDateYear === minLimitYear && renderDate.getMonth() < minLimit.getMonth()) {
+      renderDate.setMonth(minLimit.getMonth());
+    }
+  } else if (maxLimit) {
+    const renderDateYear = renderDate.getFullYear();
+    const maxLimitYear = maxLimit.getFullYear();
+
+    if (renderDateYear > maxLimitYear) {
+      renderDate.setFullYear(maxLimitYear);
+    }
+
+    if (renderDateYear === maxLimitYear && renderDate.getMonth() > maxLimit.getMonth()) {
+      renderDate.setMonth(maxLimit.getMonth());
+    }
   }
 
   return {

--- a/packages/travix-ui-kit/components/calendar/calendar.js
+++ b/packages/travix-ui-kit/components/calendar/calendar.js
@@ -71,9 +71,15 @@ function processProps(props) {
   }
 
   /** If the renderDate is not between any of the minLimit and/or maxDate, we need to redefine it. */
-  if (minLimit && (renderDate.getMonth() < minLimit.getMonth())) {
+  if (minLimit &&
+    (renderDate.getFullYear() <= minLimit.getFullYear()) &&
+    (renderDate.getMonth() < minLimit.getMonth())
+  ) {
     renderDate.setMonth(minLimit.getMonth());
-  } else if (maxLimit && (renderDate.getMonth() > maxLimit.getMonth())) {
+  } else if (maxLimit &&
+      (renderDate.getFullYear() <= maxLimit.getFullYear()) &&
+      (renderDate.getMonth() > maxLimit.getMonth())
+  ) {
     renderDate.setMonth(maxLimit.getMonth());
   }
 


### PR DESCRIPTION
**What does this PR do:**

Update check for value of renderDate with minLimit and maxLimit in Calendar and set this limit if it's required. 

Now we just compare only months for renderDate and limits. But we can have different years for example. And we now have an issue in new searchbox because of this. 

**Where should the reviewer start:**

Let me give you an example:
minDate: '2018-11-28',
maxDate: '2068-01-01',
initialDates={['2019-01-01']}

We compare first month from '2019-01-01' with eleventh from minDate, and set month from minDate to renderDate: '2019-11-01' and show wrong renderDate to user.
But we have different years and can't compare just months.

Previous behavior:
![old](https://user-images.githubusercontent.com/25330754/49141975-ddb95a00-f308-11e8-9022-bf151999d16e.gif)
New behavior:
![new](https://user-images.githubusercontent.com/25330754/49142001-e7db5880-f308-11e8-9c40-123ca520b492.gif)