### PR TITLE
[travix-ui-kit] Improve publishing process and documentation

### DIFF
--- a/packages/travix-ui-kit/MAINTAINERS.md
+++ b/packages/travix-ui-kit/MAINTAINERS.md
@@ -1,40 +1,38 @@
 # Maintainers
 
-## Pull Requests
+## Pull requests
 
-When merging Pull Requests on GitHub, use the [squash and merge](https://github.com/blog/2141-squash-your-commits) button, so that our timeline of master branch is linear.
+When merging pull requests on GitHub, use the [squash and merge](https://github.com/blog/2141-squash-your-commits) button, so that the `master` branch timeline is linear.
 
 ## Releases
 
-To publish a new release:
+To publish a new release to npm:
 
 ```
-$ git checkout master
-$ git pull origin master
-
-$ npm run build
-$ npm version patch(|minor|major)
-$ npm publish
-$ git push --follow-tags
+$ make release VERSION=<version>
 ```
 
-Or via Makefile:
+where `<version>` if one of `patch`, `minor` or `major`.
+
+### Pushing `package.json` and `package-lock.json`
+
+Once the release is published, you can commit, tag and push the updated package files:
 
 ```
-$ make release VERSION=patch
+$ make push-release
 ```
 
 ## Changelogs
 
 Changelogs are generated using the `github_changelog_generator` gem.
 
-Make sure you have Ruby v2.2+:
+Make sure you have Ruby v2.3.0+:
 
 ```
 $ gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 $ curl -sSL https://get.rvm.io | bash -s stable
 
-$ rvm install 2.2.2
+$ rvm install 2.3.0
 ```
 
 Then install the gem:
@@ -46,18 +44,18 @@ $ gem install github_changelog_generator
 Now you can generate `CHANGELOG.md` file automatically by running:
 
 ```
-$ make changelog GITHUB_API_TOKEN="YOUR_GITHUB_TOKEN"
+$ make changelog GITHUB_API_TOKEN="<your-github-token>"
 ```
 
-### GitHub API Token
+### Generating a GitHub API token
 
-You can generate a token [here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token)
+You can generate a token [here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token).
 
 Since this is a public repository, you only need `public_repo` access for the token.
 
 ### Pushing `CHANGELOG.md`
 
-Once the `CHANGELOG.md` file is generated, it is up to you to commit and push it to GitHub.
+Once the `CHANGELOG.md` file is generated, it is up to you to commit and push it.
 
 There is a handy command available:
 
@@ -65,9 +63,9 @@ There is a handy command available:
 $ make push-changelog
 ```
 
-## Adding Release Note
+## Adding release notes
 
-After `CHANGELOG.md` is pushed to GitHub, release notes should be added.
+After `CHANGELOG.md` is pushed, release notes should be added.
 
-In the repository navigate to `release` section. Here open the `Tags` tab and click on `Edit` button.
-Add your `CHANGELOG.md` notes in the editing section and save.
+In the GitHub repository page, navigate to the _Releases_ section, open the new tag and click the `Edit tag` button.
+Then, add the respective `CHANGELOG.md` notes in the description field and publish the release.

--- a/packages/travix-ui-kit/Makefile
+++ b/packages/travix-ui-kit/Makefile
@@ -4,23 +4,32 @@ GITHUB_API_TOKEN := ""
 release:
 	echo "Releasing version: $(VERSION)"
 	git checkout master
-	git pull origin master
+	git pull --no-rebase origin master
 	npm run lint
 	npm test
 	npm run build
 	npm version $(VERSION)
 	npm publish
+
+push-release:
+	git checkout master
+	git pull --no-rebase origin master
 	git add package.json package-lock.json
-	git commit -v
+	VERSION_NUMBER=$$(node -p 'require("./package.json").version');\
+	GIT_TAG=v$$VERSION_NUMBER;\
+	git commit -m $$VERSION_NUMBER;\
+	git tag $$GIT_TAG;\
+	git push origin master;\
+	git push origin $$GIT_TAG
 
 changelog:
 	git checkout master
-	git pull origin master
+	git pull --no-rebase origin master
 	github_changelog_generator -t $(GITHUB_API_TOKEN) -u Travix-International -p ui
 
 push-changelog:
 	git checkout master
-	git pull origin master
+	git pull --no-rebase origin master
 	git add CHANGELOG.md
 	git commit -m 'changelog updated.'
 	git push origin master


### PR DESCRIPTION
### What does this PR do:

- Add `push-release` rule to automate git commits and tags based on `package.json` version.
- Add `--no-rebase` flag to `git pull` commands to allow pull with unstaged changes.
- Update `MAINTAINERS.md` file with new instructions.