### PR TITLE
Set default date for changing month in calendar

### DIFF
--- a/packages/travix-ui-kit/components/calendar/calendar.js
+++ b/packages/travix-ui-kit/components/calendar/calendar.js
@@ -139,7 +139,7 @@ export default class Calendar extends Component {
 
     this.setState(({ renderDate }) => {
       const newDate = new Date(renderDate);
-      newDate.setMonth(renderDate.getMonth() + (direction === CALENDAR_MOVE_TO_PREVIOUS ? -1 : 1));
+      newDate.setMonth(renderDate.getMonth() + (direction === CALENDAR_MOVE_TO_PREVIOUS ? -1 : 1), 1);
       return { renderDate: newDate };
     }, () => {
       if ((direction === CALENDAR_MOVE_TO_PREVIOUS) && onNavPreviousMonth) {

--- a/packages/travix-ui-kit/tests/unit/calendar/calendar.normal.spec.js
+++ b/packages/travix-ui-kit/tests/unit/calendar/calendar.normal.spec.js
@@ -172,8 +172,8 @@ describe('Calendar (normal mode)', () => {
 
     it('should set renderDate to next/previous months when the next/previous btns are pressed', () => {
       const initialDate = '2017-03-05';
-      const initialDateObject = normalizeDate(getUTCDate(initialDate));
-      const nextMonthDateObj = normalizeDate(getUTCDate(initialDate));
+      const prevMonthDateObject = normalizeDate(getUTCDate('2017-03-01'));
+      const nextMonthDateObj = normalizeDate(getUTCDate('2017-04-01'));
 
       const nextMock = jest.fn();
       const previousMock = jest.fn();
@@ -189,16 +189,14 @@ describe('Calendar (normal mode)', () => {
       /** Clicks to go next month */
       wrapper.find('.ui-calendar-days__next-month').simulate('click');
 
-      nextMonthDateObj.setMonth(nextMonthDateObj.getMonth() + 1);
-
       expect(wrapper.state().renderDate).toEqual(nextMonthDateObj);
       expect(nextMock.mock.calls.length).toEqual(1);
       expect(nextMock.mock.calls[0][0]).toEqual(wrapper.state().renderDate);
 
-      /** Clicks to go next month */
+      /** Clicks to go previous month */
       wrapper.find('.ui-calendar-days__previous-month').simulate('click');
 
-      expect(wrapper.state().renderDate).toEqual(initialDateObject);
+      expect(wrapper.state().renderDate).toEqual(prevMonthDateObject);
       expect(previousMock.mock.calls.length).toEqual(1);
       expect(previousMock.mock.calls[0][0]).toEqual(wrapper.state().renderDate);
     });
@@ -249,8 +247,8 @@ describe('Calendar (normal mode)', () => {
 
     it('should only change the renderDate and do nothing else if nav callbacks are not defined', () => {
       const initialDate = '2017-03-05';
-      const initialDateObject = normalizeDate(getUTCDate(initialDate));
-      const nextMonthDateObj = normalizeDate(getUTCDate(initialDate));
+      const prevMonthDateObject = normalizeDate(getUTCDate('2017-03-01'));
+      const nextMonthDateObj = normalizeDate(getUTCDate('2017-04-01'));
 
       const wrapper = mount(
         <Calendar initialDates={[initialDate]} />
@@ -258,15 +256,11 @@ describe('Calendar (normal mode)', () => {
 
       /** Clicks to go next month */
       wrapper.find('.ui-calendar-days__next-month').simulate('click');
-
-      nextMonthDateObj.setMonth(nextMonthDateObj.getMonth() + 1);
-
       expect(wrapper.state().renderDate).toEqual(nextMonthDateObj);
 
-      /** Clicks to go next month */
+      /** Clicks to go previous month */
       wrapper.find('.ui-calendar-days__previous-month').simulate('click');
-
-      expect(wrapper.state().renderDate).toEqual(initialDateObject);
+      expect(wrapper.state().renderDate).toEqual(prevMonthDateObject);
     });
 
     it('should only change the selectedDate and do nothing else if selection callbacks are not defined', () => {


### PR DESCRIPTION
**What does this PR do:**
Set the 1st day of a month as a default value for renderDate when we go to next/prev months.

Previously if we selected 31th of January and went to next month we'd skip February and saw March because February has 28 days but it set 31 dates for next month and a renderDate was equal 3rd of March.
![skip-month](https://user-images.githubusercontent.com/25330754/53006577-84178600-3446-11e9-8f82-6d4ae5cf2683.gif)

Now we set the 1st day of a month as a default value for renderDate when we change a month.
![fixed-skip-month](https://user-images.githubusercontent.com/25330754/53006586-8974d080-3446-11e9-86ec-d109cbd8a43e.gif)
