### PR TITLE
add new color: primary-darker-rgb

### DIFF
--- a/packages/themes/themes/_default.yaml
+++ b/packages/themes/themes/_default.yaml
@@ -33,6 +33,7 @@ generic:
     accent: &accent                           "#F6E41F"
 
     primary-darker: &primary-darker           "#003F7F"
+    primary-darker-rgb: &primary-darker-rgb   ${rgb(color["primary-darker"])}
     primary-dark: &primary-dark               "#004B94"
     primary: &primary                         "#0056A9"
     primary-light: &primary-light             "#005FBB"

--- a/packages/travix-ui-kit/themes/_default.yaml
+++ b/packages/travix-ui-kit/themes/_default.yaml
@@ -33,6 +33,7 @@ generic:
     accent-top: &accent-top                     "#FFD97C"
 
     primary-darker: &primary-darker             "#979ea3"
+    primary-darker-rgb: &primary-darker-rgb     "151,158,163"
     primary-dark: &primary-dark                 "#283A8E"
     primary-dark-rgb: &primary-dark-rgb         "40,58,142"
     primary: &primary                           "#3F52A9"


### PR DESCRIPTION
### What does this PR do:

Add new color: primary-darker-rgb

### Why need to add this one?
Opacity has bug on chrome version 102, we need to replace it with background color which needs to be rgb format

