### PR TITLE
Update package name ui-themes to @travix/ui-themes

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ui-themes",
-  "version": "0.1.0",
+  "name": "@travix/ui-themes",
+  "version": "1.1.4",
   "description": "Collection of UI Themes for Travix websites",
   "main": "index.js",
   "scripts": {

--- a/packages/travix-ui-kit/themes/_default.yaml
+++ b/packages/travix-ui-kit/themes/_default.yaml
@@ -33,7 +33,6 @@ generic:
     accent-top: &accent-top                     "#FFD97C"
 
     primary-darker: &primary-darker             "#979ea3"
-    primary-darker-rgb: &primary-darker-rgb     "151,158,163"
     primary-dark: &primary-dark                 "#283A8E"
     primary-dark-rgb: &primary-dark-rgb         "40,58,142"
     primary: &primary                           "#3F52A9"


### PR DESCRIPTION
### What does this PR do:
1. Update package name from ui-themes to @travix/ui-themes, since we no longer have the ownership of ui-themes in NPM, now we can publish @travix/ui-themes to NPM
2. The latest version of ui-themes in NPM is 1.1.3, so I set the version of @travix/ui-themes to 1.1.4
3. Remove the unnecessary color added before from package travix-ui-kit

